### PR TITLE
Fixed uninitialized call of variable field if VAF is None

### DIFF
--- a/neoepiscope/file_processing.py
+++ b/neoepiscope/file_processing.py
@@ -578,6 +578,8 @@ def get_vaf_pos(VCF):
                         if format_field[i] == field:
                             vaf_pos = i
                             break
+                else:
+                    return(None)
     return (vaf_pos, field)
 
 


### PR DESCRIPTION
Hi,

I came across this little bug, if a vcf does not contain a VAF field, the newest release (0.3.6) tries to access the "field" variable without initializing it. I looked into the code and found simply returning None would be a good idea in this case (as stated in your documentation).

If you have a different fix in mind, go ahead and ignore this. ;)